### PR TITLE
fix: aggiunte definizioni di due hook già presenti e utilizzati

### DIFF
--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -539,6 +539,10 @@ export declare class LGraph {
     beforeChange(info?: LGraphNode): void;
     afterChange(info?: LGraphNode): void;                       
     connectionChange(node: LGraphNode): void;
+    /** Assignable hook called after any graph change (node moved, added, removed) */
+    onAfterChange?: ((graph: LGraph, info?: LGraphNode) => void) | null;
+    /** Assignable hook called when a connection is created or removed */
+    onConnectionChange?: ((node: LGraphNode) => void) | null;
     /** returns if the graph is in live mode */
     isLive(): boolean;
     /** clears the triggered slot animation in all links (stop visual animation) */


### PR DESCRIPTION
aggiunte definizioni di due callback per eventi mancanti.
c'erano già e funzionavano già, ma mancando dalle definizioni dei tipi non si autocompletavano e serviva castare tutto ad any per poterli chiamare