### PR TITLE
feat: aggiunto nuovo evento onAfterConnectionChange chiamato quando viene fatto mouseUp dopo lo scollegamento di una connessione

### DIFF
--- a/build/litegraph.js
+++ b/build/litegraph.js
@@ -7130,6 +7130,10 @@ LGraphNode.prototype.executeAction = function(action)
                 this.connecting_pos = null;
                 this.connecting_node = null;
                 this.connecting_slot = -1;
+
+                if (this.graph && this.graph.onAfterConnectionChange) {
+                    this.graph.onAfterConnectionChange();
+                }
             } //not dragging connection
             else if (this.resizing_node) {
                 this.dirty_canvas = true;

--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -543,6 +543,8 @@ export declare class LGraph {
     onAfterChange?: ((graph: LGraph, info?: LGraphNode) => void) | null;
     /** Assignable hook called when a connection is created or removed */
     onConnectionChange?: ((node: LGraphNode) => void) | null;
+    /** Assignable hook called once a connection drag interaction has fully ended (after connecting state is cleared) */
+    onAfterConnectionChange?: (() => void) | null;
     /** returns if the graph is in live mode */
     isLive(): boolean;
     /** clears the triggered slot animation in all links (stop visual animation) */

--- a/src/litegraph.js
+++ b/src/litegraph.js
@@ -7130,6 +7130,10 @@ LGraphNode.prototype.executeAction = function(action)
                 this.connecting_pos = null;
                 this.connecting_node = null;
                 this.connecting_slot = -1;
+
+                if (this.graph && this.graph.onAfterConnectionChange) {
+                    this.graph.onAfterConnectionChange();
+                }
             } //not dragging connection
             else if (this.resizing_node) {
                 this.dirty_canvas = true;


### PR DESCRIPTION
L'evento che c'era connectionChange veniva chiamato immediatamente dopo l'inizio di un drag di una connessione pre-esistente, mi serviva un evento a fine dell'operazione di scollegamento di una connessione (così da poter aggiornare il BE sul fatto che la connessione era stata tolta).