### PR TITLE
feat: aggiunte costanti per tipi di nodi LG per WJ

### DIFF
--- a/build/litegraph.js
+++ b/build/litegraph.js
@@ -29542,6 +29542,13 @@ LiteGraph.registerNodeType("network/httprequest", HTTPRequestNode);
     var LiteGraph = global.LiteGraph;
     if (!LiteGraph) return;
 
+    var WaterjadeNodeTypes = {
+        NODE: "waterjade/node",
+        HRU_INPUT: "waterjade/hru_input",
+        HRU_OUTPUT: "waterjade/hru_output",
+    };
+    LiteGraph.WaterjadeNodeTypes = WaterjadeNodeTypes;
+
     var DEFAULT_TYPE = "wj";
     var ORANGE = "#F08C00";
     var WHITE = "#FFFFFF";
@@ -29884,7 +29891,7 @@ LiteGraph.registerNodeType("network/httprequest", HTTPRequestNode);
         }
     };
     applyVisualMixin(WaterjadeNode.prototype);
-    LiteGraph.registerNodeType("waterjade/node", WaterjadeNode);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.NODE, WaterjadeNode);
 
     // ---- HRU Input ----
     function HRUInput() {
@@ -29908,7 +29915,7 @@ LiteGraph.registerNodeType("network/httprequest", HTTPRequestNode);
         ];
     };
     applyVisualMixin(HRUInput.prototype);
-    LiteGraph.registerNodeType("waterjade/hru_input", HRUInput);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.HRU_INPUT, HRUInput);
 
     // ---- HRU Output ----
     function HRUOutput() {
@@ -29932,5 +29939,5 @@ LiteGraph.registerNodeType("network/httprequest", HTTPRequestNode);
         ];
     };
     applyVisualMixin(HRUOutput.prototype);
-    LiteGraph.registerNodeType("waterjade/hru_output", HRUOutput);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.HRU_OUTPUT, HRUOutput);
 })(this);

--- a/src/litegraph.d.ts
+++ b/src/litegraph.d.ts
@@ -210,6 +210,12 @@ export const LiteGraph: {
     TRANSPARENT_TITLE: 2;
     AUTOHIDE_TITLE: 3;
 
+    WaterjadeNodeTypes: {
+        readonly NODE: "waterjade/node";
+        readonly HRU_INPUT: "waterjade/hru_input";
+        readonly HRU_OUTPUT: "waterjade/hru_output";
+    };
+
     node_images_path: string;
 
     debug: boolean;

--- a/src/nodes/waterjade.js
+++ b/src/nodes/waterjade.js
@@ -25,6 +25,13 @@
     var LiteGraph = global.LiteGraph;
     if (!LiteGraph) return;
 
+    var WaterjadeNodeTypes = {
+        NODE: "waterjade/node",
+        HRU_INPUT: "waterjade/hru_input",
+        HRU_OUTPUT: "waterjade/hru_output",
+    };
+    LiteGraph.WaterjadeNodeTypes = WaterjadeNodeTypes;
+
     var DEFAULT_TYPE = "wj";
     var ORANGE = "#F08C00";
     var WHITE = "#FFFFFF";
@@ -367,7 +374,7 @@
         }
     };
     applyVisualMixin(WaterjadeNode.prototype);
-    LiteGraph.registerNodeType("waterjade/node", WaterjadeNode);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.NODE, WaterjadeNode);
 
     // ---- HRU Input ----
     function HRUInput() {
@@ -391,7 +398,7 @@
         ];
     };
     applyVisualMixin(HRUInput.prototype);
-    LiteGraph.registerNodeType("waterjade/hru_input", HRUInput);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.HRU_INPUT, HRUInput);
 
     // ---- HRU Output ----
     function HRUOutput() {
@@ -415,5 +422,5 @@
         ];
     };
     applyVisualMixin(HRUOutput.prototype);
-    LiteGraph.registerNodeType("waterjade/hru_output", HRUOutput);
+    LiteGraph.registerNodeType(WaterjadeNodeTypes.HRU_OUTPUT, HRUOutput);
 })(this);


### PR DESCRIPTION
Aggiunte costanti per i tipi di nodi di WJ, in modo che nel frontend di WJ ci si possa riferire ai tipi di nodi senza bisogno di avere enum duplicati lato FE o di avere stringhe hardcodate